### PR TITLE
Replace doMC by doParallel

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ Imports:
     ForeCA,
     fracdiff,
     forecast (>= 8.3),
-    doMC,
+    doParallel,
     geigen,
     MASS,
     mgcv,

--- a/R/featurematrix.R
+++ b/R/featurematrix.R
@@ -46,7 +46,7 @@ tsfeatures <- function(tslist,
 	  if(parallel)
 	  {
 	    num.cores <- parallel::detectCores()
-	    doMC::registerDoMC(num.cores)
+            doParallel::registerDoParallel(cores=num.cores)
 	    `%dopar%` <- foreach::`%dopar%`
 	    flist[[i]] <- foreach::foreach(j = seq_along(tslist)) %dopar% {
 	      match.fun(features[i])(tslist[[j]], ...)}


### PR DESCRIPTION
doMC do not work on Windows machines. By using doParallel a wider audience (including me) can use this package. 