### PR TITLE
Fixed url for yahoo_data

### DIFF
--- a/R/yahoo.R
+++ b/R/yahoo.R
@@ -18,7 +18,7 @@
 #' @export
 yahoo_data <- function(...){
   tmp <- tempfile()
-  download.file("https://github.com/robjhyndman/tsfeatures/raw/master/data/yahoo.rda", tmp, ...)
+  download.file("https://github.com/robjhyndman/tsfeatures/raw/master/extra-data/yahoo.rda", tmp, ...)
   load(tmp)
   yahoo
 }


### PR DESCRIPTION
The old url was used for testing the vignette and made its way into the last quickfix. oops.